### PR TITLE
ci: sanitize out quotes from version

### DIFF
--- a/.github/workflows/make-draft-release.yaml
+++ b/.github/workflows/make-draft-release.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get Version
         run: |
-          echo "$(grep 'version =' < pyproject.toml | tr -d ' ')" >> "$GITHUB_ENV"
+          echo "$(grep 'version =' < pyproject.toml | tr -d ' "')" >> "$GITHUB_ENV"
 
       - name: Make Draft Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
I'd expected `version="blah"` to work, but it ended up leaving the escaped quotes in the version number.