### PR TITLE
ci: upgrade to supported pypi-publish action

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -29,7 +29,7 @@ jobs:
         run: uv build --sdist --wheel
 
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The `master` branch no longer works. They recommend swapping to the stable or unstable v1 release, or pinning a hash.

https://github.com/webrecorder/authsign/actions/runs/33027961108/job/98373630956