### PR TITLE
packaging: restore trusted certs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,5 @@ authsign = "authsign"
 
 [tool.setuptools.package-data]
 authsign = ["log.json"]
+"authsign.trusted" = ["*"]
 


### PR DESCRIPTION
We missed these when migrating to pyproject.toml.